### PR TITLE
Add cheat to modify specific equipped item rarity

### DIFF
--- a/mods/braindance_protocol/cheats/modify.lua
+++ b/mods/braindance_protocol/cheats/modify.lua
@@ -1,0 +1,31 @@
+local Modify = {
+	rootPath = "plugins.cyber_engine_tweaks.mods.braindance_protocol."
+}
+
+local Utilities = require(Modify.rootPath.."utility")
+
+function Modify.Set(cat, slot, rarity)
+    local moduleName = "Modify."
+    Utilities.StartProtocol(moduleName)
+
+	player = Game.GetPlayer()
+	ssc = Game.GetScriptableSystemsContainer()
+	ts = Game.GetTransactionSystem()
+	es = ssc:Get(CName.new('EquipmentSystem'))
+	cs = ssc:Get(CName.new('CraftingSystem'))
+
+	espd = es:GetPlayerData(player)
+	espd['GetItemInEquipSlot2'] = espd['GetItemInEquipSlot;gamedataEquipmentAreaInt32']
+	cs['SetItemLevel2'] = cs['SetItemLevel;gameItemData']
+
+	itemid = espd:GetItemInEquipSlot2(cat, slot)
+	if itemid.tdbid.hash ~= 0 then 
+		itemdata = ts:GetItemData(player, itemid)
+		cs:SetItemLevel2(itemdata)
+		Game['gameRPGManager::ForceItemQuality;GameObjectgameItemDataCName'](player, itemdata, CName.new(rarity))
+	end
+	
+    Utilities.FinishProtocol(moduleName)
+end
+
+return Modify

--- a/mods/braindance_protocol/init.lua
+++ b/mods/braindance_protocol/init.lua
@@ -23,7 +23,8 @@ function BraindanceProtocol:new()
 		Johnny = require(BraindanceProtocol.rootPath.."cheats.johnny"),
 		Player = require(BraindanceProtocol.rootPath.."cheats.player"),
 		Legend = require(BraindanceProtocol.rootPath.."cheats.legend"),
-		Platform = require(BraindanceProtocol.rootPath.."cheats.platform")
+		Platform = require(BraindanceProtocol.rootPath.."cheats.platform"),
+		Modify = require(BraindanceProtocol.rootPath.."cheats.modify")
 	}
 
 	-- Execute Braindance protocols


### PR DESCRIPTION
Added new cheat with usage:

`BD.Cheats.Modify.Set(cat, slot, rarity)`

where `cat` is a category string (`'Weapon'`, `'Consumable'`, etc.), slot is the zero-indexed slot, and rarity is the rarity level (`'Uncommon'`, `'Common'`, `'Rare'`, `'Epic'`, `'Legendary'`).